### PR TITLE
Add Kalman Filter for RANSAC outputs

### DIFF
--- a/enhanced_ransac_ground_segmentation/config/enhanced_ransac.yaml
+++ b/enhanced_ransac_ground_segmentation/config/enhanced_ransac.yaml
@@ -8,9 +8,8 @@
 # Global settings for the main application loop.
 
 verbose: false        # Enable/disable detailed console output for the main application.
-timer: false           # Enable/disable performance timers for each processing step.
+timer: true           # Enable/disable performance timers for each processing step.
 frequency: 15         # Target loop frequency in Hz. The program will pause to not exceed this rate.
-result_path: "~/Documents/github/enhanced_RANSAC_ground_segmentation/results" # Path to save any output files.
 
 # -------------------------------------------------------------------
 # DATA LOADER SETTINGS
@@ -20,7 +19,7 @@ result_path: "~/Documents/github/enhanced_RANSAC_ground_segmentation/results" # 
 point_cloud_loader:
   verbose: false      # Print debug information specific to the data loader.
   point_cloud_paths:  # List of paths to the KITTI velodyne_points/data directories.
-    # - /home/mh/Documents/kitti/2011_09_26_drive_0101_sync/2011_09_26/2011_09_26_drive_0101_sync/velodyne_points/data
+    - /home/mh/Documents/kitti/2011_09_26_drive_0101_sync/2011_09_26/2011_09_26_drive_0101_sync/velodyne_points/data
     - /home/mh/Documents/kitti/2011_09_29_drive_0071_sync/2011_09_29/2011_09_29_drive_0071_sync/velodyne_points/data
     - /home/mh/Documents/kitti/2011_09_30_drive_0033_sync/2011_09_30/2011_09_30_drive_0033_sync/velodyne_points/data
   point_cloud_type: xyzi # Point format. Options: xyzi, xyz, xyi, xyzrgb
@@ -34,8 +33,8 @@ box_filter:
   enable: true       # If true, keeps only points within the defined XYZ box.
   xmin: -10.0         # Minimum X coordinate (meters).
   xmax: 10.0          # Maximum X coordinate (meters).
-  ymin: -10.0         # Minimum Y coordinate (meters).
-  ymax: 10.0          # Maximum Y coordinate (meters).
+  ymin: -6.0         # Minimum Y coordinate (meters).
+  ymax: 6.0          # Maximum Y coordinate (meters).
   zmin: -3.0          # Minimum Z coordinate (meters).
   zmax: 1.0           # Maximum Z coordinate (meters).
 
@@ -44,7 +43,7 @@ voxel_filter:
   voxel_size: 0.30    # The size of each voxel in meters. Larger values reduce points more.
 
 noise_filter:
-  enable: true        # If true, removes points considered to be statistical outliers.
+  enable: false        # If true, removes points considered to be statistical outliers.
   mean_k: 10          # Number of nearest neighbors to analyze for each point.
   std_dev: 2.0        # Standard deviation multiplier threshold. Points with a distance larger
                       # than this multiplier of the mean distance will be removed.
@@ -64,12 +63,25 @@ ransac:
 ground_estimation:
   enable: true             # Master switch for the entire ground estimation process.
   verbose: true            # Print debug info for the ground estimation logic.
-  buffer_size: 20          # Number of recent valid planes to store for the moving average fallback.
   max_angle: 20.0          # Max angle (degrees) between a plane's normal and the Z-axis to be
                            # considered a valid ground plane. Prevents walls/ramps from being chosen.
   max_height: 2.0          # Max height (meters) of the ground plane's 'd' coefficient.
   min_points: 30           # Minimum number of points required in the cloud for estimation to proceed.
-  z_offset: 0.0            # An offset (meters) to vertically adjust the final ground plane.
+  z_offset: 0.15            # An offset (meters) to vertically adjust the final ground plane.
+
+  temporal_filter:
+    enable: true            # If true, applies a temporal filter to stabilize the ground plane estimate.
+    method: "kalman_filter" # moving_average | kalman_filter
+    moving_average:
+      buffer_size: 10           # Number of recent planes to average for stability.
+    kalman_filter:
+      # process_noise / measurement_noise: high value more responsive to changes, low value more stable.
+      # High value will adapt to changes quickly, low value will be more stable.
+      process_noise: 0.8       # Process noise covariance for the Kalman filter.
+      # High value increases smoothness, low value allows more noise.
+      measurement_noise: 0.1    # Measurement noise covariance for the Kalman filter.
+      # High value means the fitler starts with very low confidence in the initial state.
+      initial_covariance: 2.0   # Initial covariance for the Kalman filter.
 
   wall_filter:
     enable: false          # If true, attempts to detect and filter out vertical walls before re-running RANSAC.

--- a/enhanced_ransac_ground_segmentation/config/enhanced_ransac.yaml
+++ b/enhanced_ransac_ground_segmentation/config/enhanced_ransac.yaml
@@ -8,7 +8,7 @@
 # Global settings for the main application loop.
 
 verbose: false        # Enable/disable detailed console output for the main application.
-timer: true           # Enable/disable performance timers for each processing step.
+timer: false           # Enable/disable performance timers for each processing step.
 frequency: 15         # Target loop frequency in Hz. The program will pause to not exceed this rate.
 result_path: "~/Documents/github/enhanced_RANSAC_ground_segmentation/results" # Path to save any output files.
 
@@ -21,7 +21,7 @@ point_cloud_loader:
   verbose: false      # Print debug information specific to the data loader.
   point_cloud_paths:  # List of paths to the KITTI velodyne_points/data directories.
     # - /home/mh/Documents/kitti/2011_09_26_drive_0101_sync/2011_09_26/2011_09_26_drive_0101_sync/velodyne_points/data
-    # - /home/mh/Documents/kitti/2011_09_29_drive_0071_sync/2011_09_29/2011_09_29_drive_0071_sync/velodyne_points/data
+    - /home/mh/Documents/kitti/2011_09_29_drive_0071_sync/2011_09_29/2011_09_29_drive_0071_sync/velodyne_points/data
     - /home/mh/Documents/kitti/2011_09_30_drive_0033_sync/2011_09_30/2011_09_30_drive_0033_sync/velodyne_points/data
   point_cloud_type: xyzi # Point format. Options: xyzi, xyz, xyi, xyzrgb
 
@@ -64,7 +64,7 @@ ransac:
 ground_estimation:
   enable: true             # Master switch for the entire ground estimation process.
   verbose: true            # Print debug info for the ground estimation logic.
-  buffer_size: 1           # Number of recent valid planes to store for the moving average fallback.
+  buffer_size: 20          # Number of recent valid planes to store for the moving average fallback.
   max_angle: 20.0          # Max angle (degrees) between a plane's normal and the Z-axis to be
                            # considered a valid ground plane. Prevents walls/ramps from being chosen.
   max_height: 2.0          # Max height (meters) of the ground plane's 'd' coefficient.

--- a/enhanced_ransac_ground_segmentation/include/ground_estimation.h
+++ b/enhanced_ransac_ground_segmentation/include/ground_estimation.h
@@ -9,6 +9,7 @@
 
 #include "ransac.h"
 #include "wall_filter.h"
+#include "kalman_filter.h"
 
 #include <memory>
 #include <deque>
@@ -71,15 +72,26 @@ private:
 
     bool enable_;                           ///< Enable or disable ground estimation
     bool verbose_;                          ///< Enable verbose output for debugging
-    std::deque<std::vector<float>> buffer_; ///< Buffer storing recent ground plane estimates.
-    int buffer_size_;           ///< Maximum size of the history buffer.
+
     float max_angle_;           ///< Maximum allowable ground plane angle.
     float max_height_;          ///< Maximum allowable ground plane height.
     int min_points_;            ///< Minimum number of points required for estimation.
     float z_offset_;            ///< Offset to adjust the ground plane height, useful for fine-tuning.
+
     bool wall_filter_enabled_;  ///< Flag indicating if wall filtering is enabled.
     int max_rerun_times_;       ///< Maximum number of RANSAC retries for wall filtering.
     float wall_threshold_;      ///< Threshold for determining if a plane resembles a wall.
+
+    bool temporal_filter_enabled_; ///< Enable or disable temporal filtering (e.g., Kalman filter or moving average).
+    std::string temporal_filter_method_;    ///< Method for temporal filtering: "moving_average" or "kalman_filter".
+
+    std::deque<std::vector<float>> buffer_; ///< Buffer storing recent ground plane estimates.
+    int buffer_size_;           ///< Maximum size of the history buffer.
+
+    std::unique_ptr<KalmanFilter> kalman_filter_; ///< Kalman filter for temporal stability.
+    double kalman_process_noise_;      ///< Process noise for the Kalman filter.
+    double kalman_measurement_noise_;  ///< Measurement noise for the Kalman filter.
+    double kalman_initial_covariance_; ///< Initial covariance for the Kalman filter.
 
     std::unique_ptr<Ransac> ransac_;            ///< RANSAC-based plane estimation.
     std::unique_ptr<WallFilter> wall_filter_;   ///< Wall filter for refining the ground estimate.

--- a/enhanced_ransac_ground_segmentation/include/ground_estimation.h
+++ b/enhanced_ransac_ground_segmentation/include/ground_estimation.h
@@ -70,6 +70,7 @@ private:
     void flipPlaneIfNecessary(std::vector<float> &plane_coeffs);
 
     bool enable_;                           ///< Enable or disable ground estimation
+    bool verbose_;                          ///< Enable verbose output for debugging
     std::deque<std::vector<float>> buffer_; ///< Buffer storing recent ground plane estimates.
     int buffer_size_;           ///< Maximum size of the history buffer.
     float max_angle_;           ///< Maximum allowable ground plane angle.

--- a/enhanced_ransac_ground_segmentation/include/kalman_filter.h
+++ b/enhanced_ransac_ground_segmentation/include/kalman_filter.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <Eigen/Dense>
+#include <vector>
+
+/**
+ * @class KalmanFilter
+ * @brief A simple 4D Kalman Filter for tracking plane coefficients [a, b, c, d].
+ *
+ * This filter assumes a constant velocity model (i.e., the plane is expected
+ * to be similar from one frame to the next). It uses the Eigen library for
+ * all linear algebra operations.
+ */
+class KalmanFilter
+{
+public:
+    /**
+     * @brief Constructor.
+     */
+    KalmanFilter();
+
+    /**
+     * @brief Initializes the filter with the first measurement.
+     * @param initial_coeffs The first set of measured plane coefficients.
+     * @param initial_covariance The initial uncertainty of the estimate.
+     * @param process_noise The uncertainty in the plane's motion model.
+     * @param measurement_noise The uncertainty of the RANSAC measurement.
+     */
+    void init(const std::vector<float>& initial_coeffs,
+              double initial_covariance,
+              double process_noise,
+              double measurement_noise);
+
+    /**
+     * @brief Predicts the state for the next time step.
+     */
+    void predict();
+
+    /**
+     * @brief Updates the state estimate with a new measurement.
+     * @param measurement The new plane coefficients from RANSAC.
+     */
+    void update(const std::vector<float>& measurement);
+
+    /**
+     * @brief Gets the current filtered state of the plane coefficients.
+     * @return A vector containing the estimated [a, b, c, d].
+     */
+    std::vector<float> getState() const;
+
+    /**
+     * @brief Checks if the filter has been initialized.
+     * @return True if initialized, false otherwise.
+     */
+    bool isInitialized() const { return is_initialized_; }
+
+private:
+    // Flag to check if the filter has been initialized
+    bool is_initialized_;
+
+    // State vector [a, b, c, d]
+    Eigen::Vector4f x_;
+
+    // State covariance matrix (P) - represents the uncertainty of the state
+    Eigen::Matrix4f P_;
+
+    // State transition matrix (F) - defines how the state evolves
+    Eigen::Matrix4f F_;
+
+    // Process noise covariance matrix (Q) - uncertainty in the motion model
+    Eigen::Matrix4f Q_;
+
+    // Measurement matrix (H) - maps the state to the measurement space
+    Eigen::Matrix4f H_;
+
+    // Measurement noise covariance matrix (R) - uncertainty of the sensor
+    Eigen::Matrix4f R_;
+};

--- a/enhanced_ransac_ground_segmentation/src/kalman_filter.cpp
+++ b/enhanced_ransac_ground_segmentation/src/kalman_filter.cpp
@@ -1,0 +1,95 @@
+#include "kalman_filter.h"
+#include <vector>
+
+KalmanFilter::KalmanFilter() : is_initialized_(false)
+{
+    // For a simple "constant plane" model, the state transition and
+    // measurement matrices are both identity matrices.
+    // This means we expect the plane to be the same in the next frame,
+    // and we are directly measuring the plane coefficients.
+    F_ = Eigen::Matrix4f::Identity();
+    H_ = Eigen::Matrix4f::Identity();
+}
+
+void KalmanFilter::init(const std::vector<float>& initial_coeffs,
+                        double initial_covariance,
+                        double process_noise,
+                        double measurement_noise)
+{
+    if (initial_coeffs.size() != 4) {
+        // Handle error: cannot initialize with incorrect dimensions
+        return;
+    }
+
+    // Set the initial state vector
+    x_ << initial_coeffs[0], initial_coeffs[1], initial_coeffs[2], initial_coeffs[3];
+
+    // Set the initial uncertainty (covariance)
+    P_ = Eigen::Matrix4f::Identity() * initial_covariance;
+
+    // Set the noise matrices based on configuration
+    Q_ = Eigen::Matrix4f::Identity() * process_noise;
+    R_ = Eigen::Matrix4f::Identity() * measurement_noise;
+
+    is_initialized_ = true;
+}
+
+void KalmanFilter::predict()
+{
+    if (!is_initialized_) {
+        return;
+    }
+
+    // Predict the state
+    // x_pred = F * x_
+    x_ = F_ * x_;
+
+    // Predict the state covariance
+    // P_pred = F * P * F^T + Q
+    P_ = F_ * P_ * F_.transpose() + Q_;
+}
+
+void KalmanFilter::update(const std::vector<float>& measurement)
+{
+    if (!is_initialized_ || measurement.size() != 4) {
+        return;
+    }
+
+    // Convert measurement vector to Eigen vector
+    Eigen::Vector4f z;
+    z << measurement[0], measurement[1], measurement[2], measurement[3];
+
+    // --- Kalman Filter Update Equations ---
+
+    // Innovation (measurement residual)
+    // y = z - H * x
+    Eigen::Vector4f y = z - H_ * x_;
+
+    // Innovation covariance
+    // S = H * P * H^T + R
+    Eigen::Matrix4f S = H_ * P_ * H_.transpose() + R_;
+
+    // Kalman Gain
+    // K = P * H^T * S^-1
+    Eigen::Matrix4f K = P_ * H_.transpose() * S.inverse();
+
+    // Updated state estimate
+    // x_new = x + K * y
+    x_ = x_ + (K * y);
+
+    // Updated state covariance
+    // P_new = (I - K * H) * P
+    long size = x_.size();
+    Eigen::Matrix4f I = Eigen::Matrix4f::Identity();
+    P_ = (I - K * H_) * P_;
+}
+
+std::vector<float> KalmanFilter::getState() const
+{
+    if (!is_initialized_) {
+        return {};
+    }
+    // Convert Eigen vector back to std::vector
+    std::vector<float> state_vec(x_.data(), x_.data() + x_.size());
+    return state_vec;
+}

--- a/enhanced_ransac_ground_segmentation/src/main.cpp
+++ b/enhanced_ransac_ground_segmentation/src/main.cpp
@@ -47,8 +47,8 @@ int main(int argc, char** argv)
     std::cout << "visualization: " << (visualization ? "true" : "false") << std::endl;
     std::cout << "ground_estimation: " << (ground_estimation ? "true" : "false") << std::endl;
 
-    std::cout << "Waiting for 5 seconds before starting..." << std::endl;
-    std::this_thread::sleep_for(std::chrono::seconds(5));
+    std::cout << "Waiting for 3 seconds before starting..." << std::endl;
+    std::this_thread::sleep_for(std::chrono::seconds(3));
 
     // Initialize components
     PointCloudLoader point_cloud_loader(config);

--- a/enhanced_ransac_ground_segmentation/src/main.cpp
+++ b/enhanced_ransac_ground_segmentation/src/main.cpp
@@ -63,7 +63,6 @@ int main(int argc, char** argv)
 
     while (point_cloud_loader.loadNextPointCloud(cloud))
     {
-        std::cout << "\033[2J\033[H";
         // Init
         auto frame_start = std::chrono::steady_clock::now();
         if (timer) std::cout << "------------------- Frame -------------------" << std::endl;


### PR DESCRIPTION
**Feat: Add Kalman Filter and Optimize Noise Filter with OpenMP**

### **Description:**

This pull request introduces two major enhancements to the processing pipeline, significantly improving both performance and the stability of the ground plane estimation.

**1. Noise Filter Optimization with OpenMP:**

The single-threaded `pcl::StatisticalOutlierRemoval` was identified as a major CPU bottleneck in the pre-processing stage. To address this, it has been replaced with a **custom, parallel implementation of the statistical outlier removal filter using OpenMP.**

* This new version effectively utilizes multiple CPU cores to process the point cloud in parallel.
* It drastically reduces the time spent on noise filtering, resolving a key performance issue and making the entire pipeline more efficient.

**2. Kalman Filter for Temporal Smoothing:**

A `KalmanFilter` has been implemented and integrated as a more advanced alternative to the moving average buffer for smoothing the RANSAC output.

* The filter tracks the four coefficients of the ground plane over time, providing a **predictive and more responsive estimate.** This is especially effective in dynamic scenarios with bumpy terrain or sharp steering.
* The choice between the `"moving_average"` and `"kalman_filter"` is now fully configurable in `config.yaml` under the `ground_estimation.temporal_filter` section, allowing for easy experimentation and tuning.

These changes make the system faster, more robust, and more flexible. The Kalman filter provides a superior method for maintaining a stable ground plane, while the OpenMP optimization removes a critical performance bottleneck.